### PR TITLE
docs: update README for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Beacon is an async notification service built in Go. It currently supports email
 
 3. Run the services:
    ```bash
-   make run-http &
+   make run-server &
    make run-email-worker
    ```
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ Beacon is an async notification service built in Go. It currently supports email
 
 ---
 
+## Features
+
+- **Async email delivery** via Temporal workflows with automatic retries
+- **Multi-provider SMTP routing** — configure multiple providers in Infisical and route by category using `client_hint`
+- **Config watcher** — hot-reloads provider configs from Infisical without restart (`CONFIG_POLL_INTERVAL`)
+- **Dead Letter Queue** — query failed workflows (`GET /dlq/failed`) and replay them (`POST /dlq/replay/{workflowID}`)
+- **Admin config refresh** — manually trigger a reload via `POST /admin/config/refresh` (requires `ADMIN_TOKEN`)
+- **Health probes** — `/healthz/live` and `/healthz/ready` for liveness and readiness checks
+
+---
+
 ## Quick Start
 
 1. Start Temporal:
@@ -41,6 +52,11 @@ Beacon is an async notification service built in Go. It currently supports email
 
 Both the HTTP server and the email worker must be running for delivery to work.
 
+For a fully local smoke test (no real Infisical instance needed), use the mock test script:
+```bash
+bash scripts/test-local.sh
+```
+
 ---
 
 ## Prerequisites
@@ -48,3 +64,4 @@ Both the HTTP server and the email worker must be running for delivery to work.
 - Go 1.24+
 - [Temporal](https://learn.temporal.io/getting_started/go/dev_environment/) running at `localhost:7233`
 - An SMTP provider or dev mode (`DEV_MODE=true`) with local SMTP vars
+- [Infisical](docs/infisical/INFISICAL_QUICKSTART.md) for production SMTP secret management (optional in dev mode)


### PR DESCRIPTION
## Summary

- **Fixes a critical bug** where `make run-http` was referenced in the Quick Start — this target does not exist in the Makefile (`make run-server` is correct), causing immediate failure for anyone following the guide
- **Adds a Features section** covering DLQ, admin config refresh, config watcher, multi-provider SMTP routing, and health probes — none of which were documented in the README
- **Improves Quick Start** with a pointer to `scripts/test-local.sh` for smoke testing without a real Infisical instance
- **Adds Infisical to Prerequisites** with a link to the quickstart guide

## Commits

Two logical commits — the bug fix is isolated so it can be cherry-picked independently if needed.

## Test plan

- [ ] Verify `make run-server` works as expected on a fresh checkout
- [ ] Verify `bash scripts/test-local.sh` runs successfully
- [ ] Confirm all linked docs (`docs/infisical/INFISICAL_QUICKSTART.md`, `docs/ARCHITECTURE.md`, etc.) resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)