### PR TITLE
fix: prevent nil httpClient panic when ConfigWatcher refreshes in DEV_MODE

### DIFF
--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -310,6 +310,9 @@ func (cs *ConfigService) GetConfig() *ConfigBundle {
 }
 
 func (cs *ConfigService) RefreshConfig(ctx context.Context) error {
+	if cs.authMethod == "dev" {
+		return nil
+	}
 	bundle, err := cs.LoadWithRetry(ctx)
 	if err != nil {
 		cs.mu.RLock()


### PR DESCRIPTION
## Summary

- In `DEV_MODE`, `ConfigService` is constructed without initialising `httpClient` (the `NewConfigService` path sets it; the dev shortcut in `init.go` does not)
- `ConfigWatcher` is always started and its periodic `RefreshConfig` call eventually reaches `cs.httpClient.Do`, panicking on a nil receiver
- Dev mode config is static (env vars at startup, no Infisical) — added an early `return nil` in `RefreshConfig` when `authMethod == "dev"` to skip all Infisical calls

## Test Plan

- [ ] Set `DEV_MODE=true` with required env vars and run `make run-server` — server must start without panic
- [ ] Send `POST /notify/email` and confirm a response (not a crash)
- [ ] Set `CONFIG_POLL_INTERVAL=5` and wait 10 s — confirm no panic after the watcher ticks
- [ ] Run `go build ./...` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)