### PR TITLE
fix: address all known bugs and gaps (B1–B3, G1–G5)

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -4,6 +4,7 @@ import (
 	"beacon/internal/config"
 	"beacon/internal/notifier"
 	"beacon/utils"
+	"errors"
 	"log/slog"
 	"net/http"
 	"os"
@@ -40,6 +41,10 @@ func (h *AdminHandler) HandleConfigRefresh(w http.ResponseWriter, req *http.Requ
 	}
 
 	if err := h.ConfigService.RefreshConfig(req.Context()); err != nil {
+		if errors.Is(err, config.ErrDevModeSkip) {
+			utils.WriteError(w, http.StatusServiceUnavailable, "config refresh is not available in DEV_MODE")
+			return
+		}
 		h.logger.Error("admin config refresh failed", slog.Any("error", err))
 		utils.WriteError(w, http.StatusInternalServerError, "config refresh failed")
 		return

--- a/internal/api/dlq.go
+++ b/internal/api/dlq.go
@@ -36,14 +36,20 @@ func (h *DLQHandler) HandleQueryFailures(w http.ResponseWriter, req *http.Reques
 	}
 
 	if raw := q.Get("from"); raw != "" {
-		if t, err := time.Parse(time.RFC3339, raw); err == nil {
-			filter.FromDate = t
+		t, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			utils.WriteError(w, http.StatusBadRequest, `invalid "from" date: must be RFC3339`)
+			return
 		}
+		filter.FromDate = t
 	}
 	if raw := q.Get("to"); raw != "" {
-		if t, err := time.Parse(time.RFC3339, raw); err == nil {
-			filter.ToDate = t
+		t, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			utils.WriteError(w, http.StatusBadRequest, `invalid "to" date: must be RFC3339`)
+			return
 		}
+		filter.ToDate = t
 	}
 	if raw := q.Get("limit"); raw != "" {
 		if v, err := strconv.Atoi(raw); err == nil {
@@ -93,6 +99,10 @@ func (h *DLQHandler) HandleReplay(w http.ResponseWriter, req *http.Request) {
 		}
 		if errors.Is(err, dlq.ErrNotTerminalState) {
 			utils.WriteError(w, http.StatusConflict, "workflow is still running; replay not allowed")
+			return
+		}
+		if errors.Is(err, dlq.ErrReplayAlreadyRunning) {
+			utils.WriteError(w, http.StatusConflict, "replay already in progress for workflow: "+workflowID)
 			return
 		}
 		h.logger.Error("DLQ replay failed", slog.String("workflow_id", workflowID), slog.Any("error", err))

--- a/internal/api/email.go
+++ b/internal/api/email.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/mail"
+	"strings"
 	"time"
 
 	"go.temporal.io/sdk/client"
@@ -38,8 +40,18 @@ func (h *EmailHandler) HandleRequest(w http.ResponseWriter, req *http.Request) {
 		utils.WriteError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
-	if request.To == "" || request.Subject == "" {
-		utils.WriteError(w, http.StatusBadRequest, "missing required fields: to, subject")
+
+	trimmedTo := strings.TrimSpace(request.To)
+	if trimmedTo == "" {
+		utils.WriteError(w, http.StatusBadRequest, "missing required field: to")
+		return
+	}
+	if request.Subject == "" {
+		utils.WriteError(w, http.StatusBadRequest, "missing required field: subject")
+		return
+	}
+	if _, err := mail.ParseAddress(trimmedTo); err != nil {
+		utils.WriteError(w, http.StatusBadRequest, "invalid email address: to")
 		return
 	}
 

--- a/internal/config/health.go
+++ b/internal/config/health.go
@@ -28,11 +28,21 @@ func (hc *HealthChecker) SetError(err error) {
 }
 
 func (hc *HealthChecker) HandleLive(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("ok"))
 }
 
 func (hc *HealthChecker) HandleReady(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
 	if !hc.ready.Load() {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		w.Write([]byte("not ready"))

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -3,14 +3,20 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
 	"time"
 )
+
+// ErrDevModeSkip is returned by RefreshConfig when running in DEV_MODE, signalling
+// that the refresh was intentionally skipped rather than silently succeeding.
+var ErrDevModeSkip = errors.New("config refresh skipped: DEV_MODE is active")
 
 type ConfigService struct {
 	infisicalAddr string
@@ -302,16 +308,14 @@ func (cs *ConfigService) GetConfig() *ConfigBundle {
 		Timestamp: cs.current.Timestamp,
 	}
 
-	for name, cfg := range cs.current.SMTP {
-		bundle.SMTP[name] = cfg
-	}
+	maps.Copy(bundle.SMTP, cs.current.SMTP)
 
 	return bundle
 }
 
 func (cs *ConfigService) RefreshConfig(ctx context.Context) error {
 	if cs.authMethod == "dev" {
-		return nil
+		return ErrDevModeSkip
 	}
 	bundle, err := cs.LoadWithRetry(ctx)
 	if err != nil {

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -310,6 +310,9 @@ func (cs *ConfigService) GetConfig() *ConfigBundle {
 }
 
 func (cs *ConfigService) RefreshConfig(ctx context.Context) error {
+	if cs.authMethod == "dev" {
+		return nil
+	}
 	bundle, err := cs.LoadWithRetry(ctx)
 	if err != nil {
 		cs.mu.RLock()

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -41,11 +42,12 @@ func (vr *ValidationResult) Error() string {
 	if vr.Valid {
 		return ""
 	}
-	msg := fmt.Sprintf("validation errors: ")
+	var sb strings.Builder
+	sb.WriteString("validation errors: ")
 	for _, err := range vr.Errors {
-		msg += fmt.Sprintf("[%s: %s] ", err.Field, err.Reason)
+		fmt.Fprintf(&sb, "[%s: %s] ", err.Field, err.Reason)
 	}
-	return msg
+	return sb.String()
 }
 
 // ValidationResult implements the error interface
@@ -169,9 +171,3 @@ func isValidHost(host string) bool {
 	return dnsRegex.MatchString(host) || host == "localhost"
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 )
@@ -35,6 +36,9 @@ func (w *ConfigWatcher) Start(ctx context.Context) {
 		case <-ticker.C:
 			prevRevision := w.service.GetRevision()
 			if err := w.service.RefreshConfig(ctx); err != nil {
+				if errors.Is(err, ErrDevModeSkip) {
+					continue
+				}
 				w.logger.Warn("config poll failed", slog.Any("error", err))
 				continue
 			}

--- a/internal/dlq/query.go
+++ b/internal/dlq/query.go
@@ -198,5 +198,5 @@ func statusMatches(status, filterStatus string) bool {
 	if filterStatus == "" {
 		return status == "Failed" || status == "TimedOut" || status == "Canceled"
 	}
-	return status == filterStatus
+	return strings.EqualFold(status, filterStatus)
 }

--- a/internal/dlq/replay.go
+++ b/internal/dlq/replay.go
@@ -6,10 +6,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/client"
+	temporalerr "go.temporal.io/sdk/temporal"
 )
 
 // ErrNotTerminalState is returned when a replay is requested for a workflow that is still running.
@@ -17,6 +17,9 @@ var ErrNotTerminalState = errors.New("workflow is not in a terminal state")
 
 // ErrWorkflowNotFound is returned when the workflow ID does not exist in Temporal.
 var ErrWorkflowNotFound = errors.New("workflow not found")
+
+// ErrReplayAlreadyRunning is returned when a replay workflow for the given ID is already in progress.
+var ErrReplayAlreadyRunning = errors.New("replay already in progress for this workflow")
 
 // replayWorkflow fetches the original workflow input and dispatches a new SendEmailWorkflow execution.
 func replayWorkflow(ctx context.Context, tc client.Client, workflowID string) (*ReplayResult, error) {
@@ -48,13 +51,18 @@ func replayWorkflow(ctx context.Context, tc client.Client, workflowID string) (*
 
 	provider := parseProviderFromTaskQueue(taskQueue)
 	replayQueue := notifier.TaskQueueFor(provider)
-	newWorkflowID := fmt.Sprintf("replay-%s-%d", workflowID, time.Now().UnixNano())
+	// Use a deterministic replay ID so Temporal itself rejects duplicate starts.
+	newWorkflowID := fmt.Sprintf("replay-%s", workflowID)
 
 	run, err := tc.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
-		ID:        newWorkflowID,
-		TaskQueue: replayQueue,
+		ID:                newWorkflowID,
+		TaskQueue:         replayQueue,
+		WorkflowIDReusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
 	}, temporal.SendEmailWorkflow, details.msg)
 	if err != nil {
+		if temporalerr.IsWorkflowExecutionAlreadyStartedError(err) {
+			return nil, ErrReplayAlreadyRunning
+		}
 		return nil, fmt.Errorf("dispatch replay workflow: %w", err)
 	}
 

--- a/scripts/mock-infisical.go
+++ b/scripts/mock-infisical.go
@@ -5,8 +5,8 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	"sync/atomic"
 	"strings"
+	"sync/atomic"
 )
 
 var (
@@ -16,12 +16,12 @@ var (
 	badJson = flag.Bool("bad-json", false, "Return invalid JSON")
 )
 
-var requestCount int64
+var requestCount atomic.Int64
 
 func main() {
 	flag.Parse()
 
-	http.HandleFunc("/api/v1/secrets", handleSecrets)
+	http.HandleFunc("/api/v4/secrets", handleSecrets)
 	fmt.Printf("Mock Infisical server listening on :%s\n", *port)
 	fmt.Printf("Config: fail-count=%d, slow-ms=%d, bad-json=%v\n", *fail, *slowMs, *badJson)
 
@@ -31,7 +31,7 @@ func main() {
 }
 
 func handleSecrets(w http.ResponseWriter, r *http.Request) {
-	count := atomic.AddInt64(&requestCount, 1)
+	count := requestCount.Add(1)
 	fmt.Printf("[%d] %s %s\n", count, r.Method, r.RequestURI)
 
 	if int(count) <= *fail {
@@ -49,7 +49,7 @@ func handleSecrets(w http.ResponseWriter, r *http.Request) {
 	secrets := []map[string]string{
 		{
 			"secretKey": "sendgrid",
-			"secretValue": mustMarshal(map[string]interface{}{
+			"secretValue": mustMarshal(map[string]any{
 				"name":       "sendgrid",
 				"provider":   "sendgrid",
 				"host":       "smtp.sendgrid.net",
@@ -57,7 +57,7 @@ func handleSecrets(w http.ResponseWriter, r *http.Request) {
 				"username":   "apikey",
 				"password":   "SG.test-key-12345",
 				"auth_type":  "PLAIN",
-				"tls":        map[string]interface{}{"enabled": true, "server_name": "smtp.sendgrid.net"},
+				"tls":        map[string]any{"enabled": true, "server_name": "smtp.sendgrid.net"},
 				"timeout":    "30s",
 				"max_retries": 3,
 				"max_per_hour": 0,
@@ -65,7 +65,7 @@ func handleSecrets(w http.ResponseWriter, r *http.Request) {
 		},
 		{
 			"secretKey": "mailgun",
-			"secretValue": mustMarshal(map[string]interface{}{
+			"secretValue": mustMarshal(map[string]any{
 				"name":       "mailgun",
 				"provider":   "mailgun",
 				"host":       "smtp.mailgun.org",
@@ -73,14 +73,14 @@ func handleSecrets(w http.ResponseWriter, r *http.Request) {
 				"username":   "postmaster@mg.example.com",
 				"password":   "mg-test-key",
 				"auth_type":  "PLAIN",
-				"tls":        map[string]interface{}{"enabled": true, "server_name": "smtp.mailgun.org"},
+				"tls":        map[string]any{"enabled": true, "server_name": "smtp.mailgun.org"},
 				"timeout":    "25s",
 				"max_retries": 2,
 			}),
 		},
 		{
 			"secretKey": "aws-ses",
-			"secretValue": mustMarshal(map[string]interface{}{
+			"secretValue": mustMarshal(map[string]any{
 				"name":       "ses",
 				"provider":   "aws-ses",
 				"host":       "email-smtp.us-east-1.amazonaws.com",
@@ -88,12 +88,12 @@ func handleSecrets(w http.ResponseWriter, r *http.Request) {
 				"username":   "AKIAIOSFODNN7EXAMPLE",
 				"password":   "test-smtp-password",
 				"auth_type":  "LOGIN",
-				"tls":        map[string]interface{}{"enabled": true, "server_name": "email-smtp.us-east-1.amazonaws.com"},
+				"tls":        map[string]any{"enabled": true, "server_name": "email-smtp.us-east-1.amazonaws.com"},
 			}),
 		},
 	}
 
-	response := map[string]interface{}{
+	response := map[string]any{
 		"secrets": secrets,
 	}
 
@@ -102,7 +102,7 @@ func handleSecrets(w http.ResponseWriter, r *http.Request) {
 	fmt.Printf("[%d] Response sent (secrets: %d)\n", count, len(secrets))
 }
 
-func mustMarshal(v interface{}) string {
+func mustMarshal(v any) string {
 	data, err := json.Marshal(v)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## Summary

Fixes all 8 issues documented in `docs/KNOWN_ISSUES.md`, found during local API testing on 2026-06-04.

### Bugs fixed

- **B1** — `POST /notify/email`: Added email format validation using `net/mail.ParseAddress`; whitespace-only and malformed `to` values now return `400` before any workflow is enqueued
- **B2** — `GET /dlq/failed?status=`: Status filter is now case-insensitive via `strings.EqualFold`; `status=failed` and `status=FAILED` now return correct results
- **B3** — Mock Infisical server path corrected from `/api/v1/secrets` to `/api/v4/secrets`, matching what `ConfigService.fetchConfigs` actually calls

### Gaps fixed

- **G1** — `POST /notify/email`: Validation now returns field-specific error messages (`"missing required field: to"` vs `"missing required field: subject"`) instead of always blaming both
- **G2** — `/healthz/live` and `/healthz/ready`: Restricted to `GET`/`HEAD` only; other methods return `405 Method Not Allowed` with an `Allow: GET, HEAD` header per RFC 7231
- **G3** — `GET /dlq/failed?from=`/`?to=`: Non-empty date params that fail RFC3339 parsing now return `400 Bad Request` instead of silently dropping the filter
- **G4** — `POST /dlq/replay/`: Added idempotency via deterministic workflow ID (`replay-{id}`) and `ALLOW_DUPLICATE_FAILED_ONLY` reuse policy; concurrent duplicate replays return `409 Conflict` while re-replay after terminal failure is still allowed
- **G5** — `POST /admin/config/refresh`: `RefreshConfig` now returns `ErrDevModeSkip` in DEV_MODE instead of `nil`; the admin endpoint returns `503 Service Unavailable` with a clear message; `ConfigWatcher` silences the error to avoid log spam

## Test plan

- [ ] `POST /notify/email` with `to: "   "` → `400 missing required field: to`
- [ ] `POST /notify/email` with `to: "not-an-email"` → `400 invalid email address: to`
- [ ] `POST /notify/email` with missing `subject` only → `400 missing required field: subject` (not both fields)
- [ ] `GET /dlq/failed?status=failed` → returns failures (same as `status=Failed`)
- [ ] `GET /dlq/failed?from=not-a-date` → `400 invalid "from" date: must be RFC3339`
- [ ] `POST /healthz/live` → `405` with `Allow: GET, HEAD` header
- [ ] `POST /dlq/replay/{id}` twice in quick succession → second call returns `409`
- [ ] `POST /admin/config/refresh` in DEV_MODE → `503 config refresh is not available in DEV_MODE`
- [ ] Mock Infisical server (`scripts/mock-infisical.go`) responds correctly when pointed at by the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)